### PR TITLE
Update jcommander 1.75 -> 1.78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.75</version>
+            <version>1.78</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Version `1.75` is causing some trouble on some JDK versions:

```
jdk-api-diff/src/main/java/module-info.java:[19,14] module not found: jcommander
```