### PR TITLE
Correctly handle the situation when a JVM picks up JAVA_TOOL_OPTIONS env

### DIFF
--- a/src/main/java/net/adoptopenjdk/jdkapidiff/repackager/JdkRepackager.java
+++ b/src/main/java/net/adoptopenjdk/jdkapidiff/repackager/JdkRepackager.java
@@ -113,7 +113,7 @@ public abstract class JdkRepackager {
 
     private static String getVersion(Path javaHome) {
         List<String> output = ProcessExecutor.run( "java", Arrays.asList( javaHome.resolve( "bin" ).resolve( "java" ).toString(), "-version" ), javaHome.resolve( "bin" ) );
-        String version = output.get( 0 );
+        String version = output.get( 0 ).contains( "JAVA_TOOL_OPTIONS" ) ? output.get( 1 ) : output.get( 0 );
         return version.substring( version.indexOf( "\"" ) + 1, version.lastIndexOf( "\"" ) );
     }
 


### PR DESCRIPTION
If `JAVA_TOOL_OPTIONS` is set, the first line of `java -version` output will actually involve a note about this on non-zero number of JDK distributions.

Happened to me today and broke the run.