### PR TITLE
Update Groovy to 3.0.9 for supporting newer JDK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
                     <dependencies>
                         <dependency>
                             <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-all</artifactId>
-                            <version>2.4.21</version>
+                            <artifactId>groovy</artifactId>
+                            <version>3.0.9</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
The latest Groovy version 3.0.9 pulls in the latest asm
version which allows us to analyze current java versions.

Fixes #16